### PR TITLE
contact_plan: Load correct delay item from tvgutil contact plans

### DIFF
--- a/pydtnsim/contact_plan.py
+++ b/pydtnsim/contact_plan.py
@@ -438,7 +438,7 @@ class ContactPlan:
                     from_time=from_time,
                     to_time=to_time,
                     datarate=datarate,
-                    delay=contact[5])
+                    delay=contact[6])
 
                 # Add two contacts (due to bidirectionality)
                 self.plan['contacts'].append(contact)


### PR DESCRIPTION
The sixth item of the tvgutil PCP contact array (contact[5]) refers to
the predicted contact probability. The delay is stored as seventh item.