### PR TITLE
Use pipenv in travis to ensure consistency

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,35 +3,34 @@ dist: xenial
 python:
   - "3.7"
 # command to install dependencies
-install:
-  - pip3 install -e ".[dev]"
+install: "make install"
 script: True
 # command to run tests
 jobs:
     include:
       - stage: "Unit Tests"
       # The unit tests should succeed when tested in python3
-      - script: python3 -m pytest tests/unittests/ -vv --color=yes
+      - script: pipenv run python3 -m pytest tests/unittests/ -vv --color=yes
         name: "Py.Test"
       - stage: "Code Quality"
       # The linter pylint somehow overlaps with flake8, but has some more checks that flake8 does not have
-      - script: python3 -m pydocstyle examples pydtnsim
+      - script: pipenv run python3 -m pydocstyle examples pydtnsim
         name: "Pydocstyle"
       # We need this additional linter because we have to ignore certain issues within the routing submodule (i.e. we want to allow redundant code to get a better representation of the semantic structures of the routing approaches)
-      - script: python3 -m pylint pydtnsim --ignore=routing
+      - script: pipenv run python3 -m pylint pydtnsim --ignore=routing
         name: "Pylint"
       # We need this additional linter because we have to ignore certain issues within the routing submodule (i.e. we want to allow redundant code to get a better representation of the semantic structures of the routing approaches)
-      - script: python3 -m pylint pydtnsim.routing -d duplicate-code -d R0912 -d R0913
+      - script: pipenv run python3 -m pylint pydtnsim.routing -d duplicate-code -d R0912 -d R0913
         name: "Pylint Routing"
       # We separate the complexity plugin functionality to get additional feedback regarding the complexity
-      - script: pylint --disable=all --load-plugins=pylint.extensions.mccabe --enable=R1260 pydtnsim --ignore=routing
+      - script: pipenv run pylint --disable=all --load-plugins=pylint.extensions.mccabe --enable=R1260 pydtnsim --ignore=routing
         name: "Pylint Complexity"
       - stage: "Routing Tests"
       # Check that all CGR routing implementations provide the same results
-      - script: export PYTHONHASHSEED=1; python3 tests/routingtests/equivalence_check.py -q
+      - script: export PYTHONHASHSEED=1; pipenv run python3 tests/routingtests/equivalence_check.py -q
         name: "Equivalence Check"
       # Check that all CGR routing implementations provide deterministic results when executed in a deterministic environment
-      - script: python3 tests/routingtests/determinism_check.py -q
+      - script: pipenv run python3 tests/routingtests/determinism_check.py -q
         name: "Determinism Check"
       - stage: "Examples"
       # Run all examples in the examples/ folder
@@ -39,8 +38,8 @@ jobs:
         name: "Examples Test Run"
       - stage: "Integration Tests"
       # Check compatibility with "old" tvg_tools
-      - script: python3 tests/integrationtests/tvg_tools_old_test.py
+      - script: pipenv run python3 tests/integrationtests/tvg_tools_old_test.py
         name: "TVG Tool (Old)"
       # Check compatibility with tvg_util tools
-      - script: python3 tests/integrationtests/tvg_tools_new_test.py
+      - script: pipenv run python3 tests/integrationtests/tvg_tools_new_test.py
         name: "TVG Util (New)"

--- a/Makefile
+++ b/Makefile
@@ -1,13 +1,14 @@
+.PHONY: docs install help
+
 help:
 	@echo "The following targets are available:"
 	@echo
 	@echo "test:  Run unittests with pytest"
 	@echo "docs:  Genertate HTML Sphinx documentation"
 
-test:
-	pytest tests/
+install:
+	pip install pipenv --upgrade
+	pipenv install --dev
 
 docs:
 	cd docs; make html
-
-.PHONY: test docs

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ setup(
             'pytest>=3.0, <4.0',
             'Sphinx>=1.0, <2.0',
             'sphinx_rtd_theme==0.4.2',
-            'pylint==2.2.2',
+            'pylint>=2.0, <3.0',
             'pydocstyle>2.0, <3.0',
             'termcolor>=1.0, <2.0'
         ]

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ setup(
             'pytest>=3.0, <4.0',
             'Sphinx>=1.0, <2.0',
             'sphinx_rtd_theme==0.4.2',
-            'pylint>=2.0, <3.0',
+            'pylint==2.2.2',
             'pydocstyle>2.0, <3.0',
             'termcolor>=1.0, <2.0'
         ]


### PR DESCRIPTION
~~This is a quickfix to ensure, that pylint always checks the same things. As observed before, if the version is not locked down it can happen that new checks are added in a newer (minor) version that are then failing.~~

~~For consistency purposes, this is undesired. If older commits would be rerun in travis with the new version, they would now also fail.~~

~~Therefore, `pylint` is for now locked down to 2.2.2. This is only of temporary nature.~~ At a later point in time, the whole travis CI implementation will be modified to make use of `pipenv`.